### PR TITLE
Improving Perceptron Code

### DIFF
--- a/NeuralNetwork/NeuralNetwork/Matrix.cpp
+++ b/NeuralNetwork/NeuralNetwork/Matrix.cpp
@@ -5,9 +5,7 @@ Matrix::Matrix(const int rows, const int columns)
     assert(columns >= 1 && rows >= 1);
     _rows = rows;
     _columns = columns;
-    std::size_t arraySize = columns * rows * sizeof(float);
-    _values = (float*) malloc(arraySize);
-    fill(0.0f);
+    _values = (float*) calloc(columns * rows, sizeof(float));
 }
 
 Matrix::~Matrix()
@@ -37,17 +35,6 @@ int Matrix::getRows() const
 int Matrix::getColumns() const
 {
     return _columns;
-}
-
-void Matrix::fill(float value)
-{
-    for (int r = 0; r < _rows; r++)
-    {
-        for (int c = 0; c < _columns; c++)
-        {
-            set(r, c, value);
-        }
-    }
 }
 
 void Matrix::print(std::ostream& stream)
@@ -86,55 +73,50 @@ Matrix* Matrix::clone()
 }
 
 //STATIC FUNCTIONS
-Matrix* Matrix::multiply(Matrix* const left, Matrix* const right)
+Matrix* Matrix::multiply(const Matrix& left, const Matrix& right)
 {
-    Matrix* result = nullptr;
-    multiply(left, right, result);
+    Matrix* result = new Matrix(left.getRows(),right.getColumns());
+    multiply(left, right, *result);
     return result;
 }
 
-void Matrix::multiply(Matrix* const left, Matrix* const right, Matrix*& output)
+void Matrix::multiply(const Matrix& left, const Matrix& right, Matrix& output)
 {
-    assert(left != nullptr && right != nullptr);
-    assert(left->getColumns() == right->getRows());
-
-    output = new Matrix(left->getRows(),right->getColumns());
-    for(int row = 0; row < output->getRows(); ++row)
+    assert(left.getColumns() == right.getRows());
+    for(int row = 0; row < output.getRows(); ++row)
     {
-        for(int column = 0; column < output->getColumns(); ++column)
+        for(int column = 0; column < output.getColumns(); ++column)
         {
             float sum = 0.0;
-            for(int leftColumn = 0; leftColumn < left->getColumns(); ++leftColumn)
+            for(int leftColumn = 0; leftColumn < left.getColumns(); ++leftColumn)
             {
-                sum += left->get(row, leftColumn) * right->get(leftColumn, column);
+                sum += left.get(row, leftColumn) * right.get(leftColumn, column);
             }
-            output->set(row, column, sum);
+            output.set(row, column, sum);
         }
     }
 }
 
-void Matrix::multiply(Matrix*& target, const float scalar)
+void Matrix::multiply(Matrix& target, const float scalar)
 {
-    assert(target != 0);
-    for (int r = 0; r < target->getRows(); ++r)
+    for (int r = 0; r < target.getRows(); ++r)
     {
-        for (int c = 0; c < target->getColumns(); ++c)
+        for (int c = 0; c < target.getColumns(); ++c)
         {
-            float value = target->get(r,c) * scalar;
-            target->set(r,c,value);
+            float value = target.get(r,c) * scalar;
+            target.set(r,c,value);
         }
     }
 }
 
-void Matrix::add(Matrix*& matrix, const float value)
+void Matrix::add(Matrix& matrix, const float value)
 {
-    assert(matrix != 0);
-    for (int r = 0; r < matrix->getRows(); ++r)
+    for (int r = 0; r < matrix.getRows(); ++r)
     {
-        for (int c = 0; c < matrix->getColumns(); ++c)
+        for (int c = 0; c < matrix.getColumns(); ++c)
         {
-            float sum = matrix->get(r,c) + value;
-            matrix->set(r,c,sum);
+            float sum = matrix.get(r,c) + value;
+            matrix.set(r,c,sum);
         }
     }
 }

--- a/NeuralNetwork/NeuralNetwork/Matrix.cpp
+++ b/NeuralNetwork/NeuralNetwork/Matrix.cpp
@@ -80,19 +80,19 @@ Matrix* Matrix::multiply(const Matrix& left, const Matrix& right)
     return result;
 }
 
-void Matrix::multiply(const Matrix& left, const Matrix& right, Matrix& output)
+void Matrix::multiply(const Matrix& left, const Matrix& right, Matrix& target)
 {
     assert(left.getColumns() == right.getRows());
-    for(int row = 0; row < output.getRows(); ++row)
+    for(int row = 0; row < target.getRows(); ++row)
     {
-        for(int column = 0; column < output.getColumns(); ++column)
+        for(int column = 0; column < target.getColumns(); ++column)
         {
             float sum = 0.0;
             for(int leftColumn = 0; leftColumn < left.getColumns(); ++leftColumn)
             {
                 sum += left.get(row, leftColumn) * right.get(leftColumn, column);
             }
-            output.set(row, column, sum);
+            target.set(row, column, sum);
         }
     }
 }
@@ -109,14 +109,14 @@ void Matrix::multiply(Matrix& target, const float scalar)
     }
 }
 
-void Matrix::add(Matrix& matrix, const float value)
+void Matrix::add(Matrix& target, const float value)
 {
-    for (int r = 0; r < matrix.getRows(); ++r)
+    for (int r = 0; r < target.getRows(); ++r)
     {
-        for (int c = 0; c < matrix.getColumns(); ++c)
+        for (int c = 0; c < target.getColumns(); ++c)
         {
-            float sum = matrix.get(r,c) + value;
-            matrix.set(r,c,sum);
+            float sum = target.get(r, c) + value;
+            target.set(r, c, sum);
         }
     }
 }

--- a/NeuralNetwork/NeuralNetwork/Matrix.h
+++ b/NeuralNetwork/NeuralNetwork/Matrix.h
@@ -27,8 +27,8 @@ public:
     void applyFunction(FloatFunction function);
 
     static Matrix* multiply(const Matrix& left, const Matrix& right);
-    static void multiply(const Matrix& left, const Matrix& right, Matrix& output);
+    static void multiply(const Matrix& left, const Matrix& right, Matrix& target);
     static void multiply(Matrix& target, const float scalar);
-    static void add(Matrix& matrix, const float value);
+    static void add(Matrix& target, const float value);
 };
 #endif //NEURALNETWORK_MATRIX_H

--- a/NeuralNetwork/NeuralNetwork/Matrix.h
+++ b/NeuralNetwork/NeuralNetwork/Matrix.h
@@ -21,15 +21,14 @@ public:
     void set(const int row, const int column, const float value);
     int getRows() const;
     int getColumns() const;
-    void fill(float value);
     void print(std::ostream& stream);
     void print(std::ostream& stream, int decimalPlace);
     Matrix* clone();
     void applyFunction(FloatFunction function);
 
-    static Matrix* multiply(Matrix* const left, Matrix* const right);
-    static void multiply(Matrix* const left, Matrix* const right, Matrix*& output);
-    static void multiply(Matrix*& target, const float scalar);
-    static void add(Matrix*& matrix, const float value);
+    static Matrix* multiply(const Matrix& left, const Matrix& right);
+    static void multiply(const Matrix& left, const Matrix& right, Matrix& output);
+    static void multiply(Matrix& target, const float scalar);
+    static void add(Matrix& matrix, const float value);
 };
 #endif //NEURALNETWORK_MATRIX_H

--- a/NeuralNetwork/NeuralNetwork/Neuron.cpp
+++ b/NeuralNetwork/NeuralNetwork/Neuron.cpp
@@ -2,14 +2,14 @@
 
 Neuron::~Neuron()
 {
-    if (_weights != nullptr)
-        delete _weights;
+    if (_weights != nullptr) delete _weights;
+    if (_outputs != nullptr) delete _outputs;
 }
 
-Matrix* Neuron::feedforward(Matrix* const inputs)
+void Neuron::feedforward(const Matrix& inputs)
 {
-    Matrix* outputs = Matrix::multiply(_weights, inputs);
-    return outputs;
+    if (_outputs != nullptr) delete _outputs;
+    _outputs = Matrix::multiply(*_weights, inputs);
 }
 
 void Neuron::setWeights(Matrix* const weights)
@@ -17,6 +17,11 @@ void Neuron::setWeights(Matrix* const weights)
     if (_weights == weights) return;
     if (_weights != nullptr) delete _weights;
     _weights = weights;
+}
+
+Matrix* Neuron::getOutputs() const
+{
+    return _outputs;
 }
 
 Matrix* Neuron::getWeights() const

--- a/NeuralNetwork/NeuralNetwork/Neuron.h
+++ b/NeuralNetwork/NeuralNetwork/Neuron.h
@@ -8,12 +8,14 @@ class Neuron
 private:
     Matrix* _weights = nullptr;
     float _bias = 0.0f;
+    Matrix* _outputs;
 
 public:
     ~Neuron();
-    Matrix* feedforward(Matrix* const inputs);
+    void feedforward(const Matrix& inputs);
     void setWeights(Matrix* const weights);
     Matrix* getWeights() const;
+    Matrix* getOutputs() const;
     float getBias() const;
     void setBias(float bias);
 };

--- a/NeuralNetwork/NeuralNetwork/Perceptron.cpp
+++ b/NeuralNetwork/NeuralNetwork/Perceptron.cpp
@@ -1,11 +1,14 @@
 #include "Perceptron.h"
 
-#define SIGN(X) X >= 0.0 ? 1 : -1
-
 Perceptron::~Perceptron()
 {
     if (_neuron != nullptr)
         delete _neuron;
+}
+
+void Perceptron::setActivationFunction(FloatFunction activationFunction)
+{
+    _activationFunction = activationFunction;
 }
 
 Neuron* Perceptron::getNeuron() const
@@ -44,6 +47,7 @@ void Perceptron::train(const Matrix& inputs, const float target)
 
 float Perceptron::feedforward(const Matrix& inputs)
 {
+    assert(_activationFunction);
     assert(_neuron->getWeights()->getColumns() == inputs.getRows());
     _neuron->feedforward(inputs);
     Matrix& outputs = *_neuron->getOutputs();
@@ -52,5 +56,6 @@ float Perceptron::feedforward(const Matrix& inputs)
     {
         sum += outputs.get(r,0);
     }
-    return SIGN(sum);
+    float result = _activationFunction(sum);
+    return result;
 }

--- a/NeuralNetwork/NeuralNetwork/Perceptron.cpp
+++ b/NeuralNetwork/NeuralNetwork/Perceptron.cpp
@@ -4,8 +4,13 @@
 
 Perceptron::~Perceptron()
 {
-    if (_neuron == nullptr)
+    if (_neuron != nullptr)
         delete _neuron;
+}
+
+Neuron* Perceptron::getNeuron() const
+{
+    return _neuron;
 }
 
 Perceptron::Perceptron(int weightsLength)
@@ -14,22 +19,22 @@ Perceptron::Perceptron(int weightsLength)
     Matrix* weights = new Matrix(1, weightsLength);
     for (int c = 0; c < weights->getColumns(); ++c)
     {
-        float randomValue = (float(rand())/float((RAND_MAX)) * 2.0) - 1.0; //value in range -1.0/1.0
+        float randomValue = (float(rand())/float((RAND_MAX)) * 2.0f) - 1.0f; //value in range -1.0/1.0
         weights->set(0,c,randomValue);
     }
     _neuron->setWeights(weights);
-    float randomBias = (float(rand())/float((RAND_MAX)) * 0.2) - 0.1; //value in range -0.1/0.1
+    float randomBias = (float(rand())/float((RAND_MAX)) * 0.2f) - 0.1f; //value in range -0.1/0.1
     _neuron->setBias(randomBias);
 }
 
-void Perceptron::train(Matrix* const inputs, const float target)
+void Perceptron::train(const Matrix& inputs, const float target)
 {
     float output = feedforward(inputs);
     float error = (target - output);
     Matrix* weights = _neuron->getWeights();
     for (int c = 0; c < weights->getColumns(); ++c)
     {
-        float value = inputs->get(c, 0) * error * _learningRate;
+        float value = inputs.get(c, 0) * error * _learningRate;
         weights->set(0, c, value);
     }
     float bias = _neuron->getBias();
@@ -37,15 +42,15 @@ void Perceptron::train(Matrix* const inputs, const float target)
     _neuron->setBias(bias);
 }
 
-float Perceptron::feedforward(Matrix* const inputs)
+float Perceptron::feedforward(const Matrix& inputs)
 {
-    assert(_neuron->getWeights()->getColumns() == inputs->getRows());
-    Matrix* outputs = _neuron->feedforward(inputs);
+    assert(_neuron->getWeights()->getColumns() == inputs.getRows());
+    _neuron->feedforward(inputs);
+    Matrix& outputs = *_neuron->getOutputs();
     float sum =  _neuron->getBias();
-    for (int r = 0; r < outputs->getRows(); ++r)
+    for (int r = 0; r < outputs.getRows(); ++r)
     {
-        sum += outputs->get(r,0);
+        sum += outputs.get(r,0);
     }
-    delete outputs;
     return SIGN(sum);
 }

--- a/NeuralNetwork/NeuralNetwork/Perceptron.h
+++ b/NeuralNetwork/NeuralNetwork/Perceptron.h
@@ -11,11 +11,8 @@ private:
 public:
     Perceptron(int weightsLength);
     ~Perceptron();
-    float feedforward(Matrix* const inputs);
-    void train(Matrix* const inputs, const float output);
-    Neuron* getNeuron() const
-    {
-        return _neuron;
-    }
+    float feedforward(const Matrix& inputs);
+    void train(const Matrix& inputs, const float output);
+    Neuron* getNeuron() const;
 };
 #endif //NEURALNETWORK_PERCEPTRON_H

--- a/NeuralNetwork/NeuralNetwork/Perceptron.h
+++ b/NeuralNetwork/NeuralNetwork/Perceptron.h
@@ -7,10 +7,12 @@ class Perceptron
 private:
     Neuron* _neuron = nullptr;
     const float _learningRate = 0.1;
+    FloatFunction _activationFunction;
 
 public:
     Perceptron(int weightsLength);
     ~Perceptron();
+    void setActivationFunction(FloatFunction activationFunction);
     float feedforward(const Matrix& inputs);
     void train(const Matrix& inputs, const float output);
     Neuron* getNeuron() const;

--- a/NeuralNetwork/NeuralNetwork/PerceptronTests.cpp
+++ b/NeuralNetwork/NeuralNetwork/PerceptronTests.cpp
@@ -17,7 +17,7 @@ void populateRandomInput(Matrix*& matrix)
 {
     for (int r = 0; r < matrix->getRows(); ++r)
     {
-        matrix->set(r,0,(float(rand())/float((RAND_MAX)) * 1000.0) - 500.0);
+        matrix->set(r,0,(float(rand())/float((RAND_MAX)) * 1000.0f) - 500.0f);
     }
 }
 
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
     {
         populateRandomInput(inputs);
         float expectedOutput = toExpectedOutput(inputs);
-        float guess = perceptron->feedforward(inputs);
+        float guess = perceptron->feedforward(*inputs);
         if (guess == expectedOutput)
         {
             correctGuesses++;
@@ -39,7 +39,7 @@ int main(int argc, char* argv[])
         else
         {
             correctGuesses = 0;
-            perceptron->train(inputs, expectedOutput);
+            perceptron->train(*inputs, expectedOutput);
         }
     }
     cout << "The network has been trained! Final weights are:" << endl;

--- a/NeuralNetwork/NeuralNetwork/PerceptronTests.cpp
+++ b/NeuralNetwork/NeuralNetwork/PerceptronTests.cpp
@@ -2,10 +2,16 @@
 
 using namespace std;
 
-///returns the expected output from given inputs
-float toExpectedOutput(Matrix*& inputs)
+float sign(float value)
 {
-    if (inputs->get(0,0) >= inputs->get(1,0))
+    float result = value >= 0.0f ? 1.0f : -1.0f;
+    return result;
+}
+
+///returns the expected output from given inputs
+float toExpectedOutput(Matrix& inputs)
+{
+    if (inputs.get(0,0) >= inputs.get(1,0))
     {
         return 1;
     }
@@ -13,11 +19,11 @@ float toExpectedOutput(Matrix*& inputs)
 }
 
 ///Populate 'matrix' with random inputs in range -500.0/500.0
-void populateRandomInput(Matrix*& matrix)
+void populateRandomInput(Matrix& matrix)
 {
-    for (int r = 0; r < matrix->getRows(); ++r)
+    for (int r = 0; r < matrix.getRows(); ++r)
     {
-        matrix->set(r,0,(float(rand())/float((RAND_MAX)) * 1000.0f) - 500.0f);
+        matrix.set(r,0,(float(rand())/float((RAND_MAX)) * 1000.0f) - 500.0f);
     }
 }
 
@@ -25,12 +31,13 @@ int main(int argc, char* argv[])
 {
     srand((unsigned int)time(NULL));
     Perceptron* perceptron = new Perceptron(2);
+    perceptron->setActivationFunction(sign);
     int correctGuesses = 0;
     Matrix* inputs = new Matrix(2, 1);
     while (correctGuesses < 1000)
     {
-        populateRandomInput(inputs);
-        float expectedOutput = toExpectedOutput(inputs);
+        populateRandomInput(*inputs);
+        float expectedOutput = toExpectedOutput(*inputs);
         float guess = perceptron->feedforward(*inputs);
         if (guess == expectedOutput)
         {


### PR DESCRIPTION
This task is part of #8 

What was introduced in this PR?
- Using `calloc(size_t,size_t)` instead of `malloc(size_t)`, so we can get rig of `fill(float)`
- Improving code legibility be using const references instead of pointers
- The Neuron class now keeps its outputs in cache and the feedforward method doesn't return it anymore. In order to get the outputs you should call `neuron.getOutputs()`
- Fixed wrong pointer validation in Perceptron's destructor